### PR TITLE
Only players and Player rounds user stories

### DIFF
--- a/Scrum Age/Board.gd
+++ b/Scrum Age/Board.gd
@@ -1,6 +1,6 @@
 extends Node2D
 
-var current_player = 1;
+var current_player = 1;		#1-based. eg player1 = 1, player5 = 5
 
 const white = Color(1, 1, 1)
 const red = Color(1, 0.262, 0.262)

--- a/Scrum Age/Board.gd
+++ b/Scrum Age/Board.gd
@@ -11,11 +11,11 @@ const purple = Color(1, 0.110, 0.898)
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-#	if(Global.meeple_counts[current_player] != 0):
-#		get_node("EndTurn").hide()
+#	if(Global.meeple_counts[current_player]!=0):
+		get_node("EndTurn").hide()
 #	else:
 #		get_node("EndTurn").show()
-	pass
+#	pass
 
 var emptySpace = load("res://assets/EmptyBox.png")
 var knight_path = load("res://assets/Meeples/knight_head.png")
@@ -53,6 +53,13 @@ func touch_slot(grid_name, slot):
 				subtractMeeples(current_player-1, 1);
 				print(Global.meeple_counts) 			#debug
 				$PlayerMenu.updateMeepleLabels(current_player);
+				if(Global.meeple_counts[current_player-1]==0):
+					get_node("EndTurn").show()
+				
+				if(Global.meeple_counts[current_player-1]==1):
+					get_node("HRGrid/Slot1").visible = false
+					get_node("HRGrid/Slot2").visible = false
+
 	else:
 		if child.booleanSlotArray[slot-1] != 0:
 			child.get_node("Slot"+str(slot)).texture_normal = emptySpace;	#remove knight texture
@@ -61,8 +68,15 @@ func touch_slot(grid_name, slot):
 			addMeeples(current_player-1, 1);
 			print(Global.meeple_counts);
 			$PlayerMenu.updateMeepleLabels(current_player);
+			if(Global.meeple_counts[current_player-1]!=0):
+				get_node("EndTurn").hide()
+			
+			if(Global.meeple_counts[current_player-1]>1):
+				get_node("HRGrid/Slot1").visible = true
+				get_node("HRGrid/Slot2").visible = true
 			
 #called specifically to handle HR since it has slightly different properties to the other grids
+#ERROR CHECK TO MAKE SURE PLAYER CANNOT CLICK HR IF 2 OTHER SLOTS ARE SELECTED
 func touchHR_slot(grid_name,slot):
 		var child = get_node(grid_name)
 	#current_player-1 is used as index <== meeple_counts[] has player 1 at index 0
@@ -77,6 +91,9 @@ func touchHR_slot(grid_name,slot):
 				subtractMeeples(current_player-1, 2);
 				print(Global.meeple_counts) 			#debug
 				$PlayerMenu.updateMeepleLabels(current_player);
+				if(Global.meeple_counts[current_player-1]==0):
+					get_node("EndTurn").show()
+	
 		else:
 			if child.booleanSlotArray[slot-1] != 0:
 				set_meeple_color(grid_name+"/Slot1", 0); #Set the texture to the player's color
@@ -88,13 +105,17 @@ func touchHR_slot(grid_name,slot):
 				addMeeples(current_player-1, 2);
 				print(Global.meeple_counts);
 				$PlayerMenu.updateMeepleLabels(current_player);
+				if(Global.meeple_counts[current_player-1]!=0):
+					get_node("EndTurn").hide()
 
 func end_Turn():
-	#learn how to move flag
-	if(current_player < 4):
+	if(current_player < 5):
 		current_player+=1
-		#$PlayerMenu.showTurn(current_player)
+		$PlayerMenu.showTurn(current_player)
 	else:
 		current_player = 1
 	
 	print("I ended!")
+	get_node("EndTurn").hide()
+	get_node("HRGrid/Slot1").visible = true
+	get_node("HRGrid/Slot2").visible = true

--- a/Scrum Age/Board.gd
+++ b/Scrum Age/Board.gd
@@ -11,6 +11,10 @@ const purple = Color(1, 0.110, 0.898)
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
+#	if(Global.meeple_counts[current_player] != 0):
+#		get_node("EndTurn").hide()
+#	else:
+#		get_node("EndTurn").show()
 	pass
 
 var emptySpace = load("res://assets/EmptyBox.png")
@@ -87,9 +91,10 @@ func touchHR_slot(grid_name,slot):
 
 func end_Turn():
 	#learn how to move flag
-	if(current_player < 5):
+	if(current_player < 4):
 		current_player+=1
-		$PlayerMenu.showTurn(current_player)
+		#$PlayerMenu.showTurn(current_player)
 	else:
 		current_player = 1
+	
 	print("I ended!")

--- a/Scrum Age/Board.gd
+++ b/Scrum Age/Board.gd
@@ -114,6 +114,7 @@ func end_Turn():
 		$PlayerMenu.showTurn(current_player)
 	else:
 		current_player = 1
+		#$PlayerMenu.showTurn(current_player)
 	
 	print("I ended!")
 	get_node("EndTurn").hide()

--- a/Scrum Age/Board.gd
+++ b/Scrum Age/Board.gd
@@ -1,6 +1,6 @@
 extends Node2D
 
-var current_player = 1
+var current_player = 1;
 
 const white = Color(1, 1, 1)
 const red = Color(1, 0.262, 0.262)
@@ -44,17 +44,52 @@ func touch_slot(grid_name, slot):
 	if child.booleanSlotArray[slot-1] == 0:
 			if (Global.meeple_counts[current_player-1] > 0):
 				set_meeple_color(grid_name+"/Slot"+str(slot), current_player); #Set the texture to the player's color
-				child.get_node("Slot"+str(slot)).texture_normal = knight_path
-				child.booleanSlotArray[slot-1] = 1;
+				child.get_node("Slot"+str(slot)).texture_normal = knight_path #get knight icon
+				child.booleanSlotArray[slot-1] = 1;		#show that the slot is now taken
 				subtractMeeples(current_player-1, 1);
 				print(Global.meeple_counts) 			#debug
 				$PlayerMenu.updateMeepleLabels(current_player);
 	else:
 		if child.booleanSlotArray[slot-1] != 0:
-			child.get_node("Slot"+str(slot)).texture_normal = emptySpace;
+			child.get_node("Slot"+str(slot)).texture_normal = emptySpace;	#remove knight texture
 			set_meeple_color(grid_name+"/Slot"+str(slot), 0);
 			child.booleanSlotArray[slot-1] = 0;
 			addMeeples(current_player-1, 1);
 			print(Global.meeple_counts);
 			$PlayerMenu.updateMeepleLabels(current_player);
+			
+#called specifically to handle HR since it has slightly different properties to the other grids
+func touchHR_slot(grid_name,slot):
+		var child = get_node(grid_name)
+	#current_player-1 is used as index <== meeple_counts[] has player 1 at index 0
+		if child.booleanSlotArray[slot-1] == 0:
+			if (Global.meeple_counts[current_player-1] > 0):
+				set_meeple_color(grid_name+"/Slot1", current_player); #Set the texture to the player's color
+				set_meeple_color(grid_name+"/Slot2", current_player); 
+				child.get_node("Slot1").texture_normal = knight_path #get knight icon
+				child.get_node("Slot2").texture_normal = knight_path 
+				child.booleanSlotArray[0] = 1;		#show that HR is taken
+				child.booleanSlotArray[1] = 1;
+				subtractMeeples(current_player-1, 2);
+				print(Global.meeple_counts) 			#debug
+				$PlayerMenu.updateMeepleLabels(current_player);
+		else:
+			if child.booleanSlotArray[slot-1] != 0:
+				set_meeple_color(grid_name+"/Slot1", 0); #Set the texture to the player's color
+				set_meeple_color(grid_name+"/Slot2", 0); 
+				child.get_node("Slot1").texture_normal = emptySpace #get knight icon
+				child.get_node("Slot2").texture_normal = emptySpace
+				child.booleanSlotArray[0] = 0;		#show that the slots are free
+				child.booleanSlotArray[1] = 0;		
+				addMeeples(current_player-1, 2);
+				print(Global.meeple_counts);
+				$PlayerMenu.updateMeepleLabels(current_player);
 
+func end_Turn():
+	#learn how to move flag
+	if(current_player < 5):
+		current_player+=1
+		$PlayerMenu.showTurn(current_player)
+	else:
+		current_player = 1
+	print("I ended!")

--- a/Scrum Age/Board.tscn
+++ b/Scrum Age/Board.tscn
@@ -518,7 +518,7 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="ToolsButton1" type="TextureButton" parent="ToolGrid"]
+[node name="Slot1" type="TextureButton" parent="ToolGrid"]
 margin_right = 61.0
 margin_bottom = 63.0
 texture_normal = ExtResource( 5 )
@@ -573,4 +573,4 @@ __meta__ = {
 [connection signal="pressed" from="TestingGrid/Slot9" to="TestingGrid" method="_on_Slot_pressed" binds= [ 9 ]]
 [connection signal="pressed" from="HRGrid/Slot1" to="HRGrid" method="_on_Slot_pressed" binds= [ 1 ]]
 [connection signal="pressed" from="HRGrid/Slot2" to="HRGrid" method="_on_Slot_pressed" binds= [ 2 ]]
-[connection signal="pressed" from="ToolGrid/ToolsButton1" to="ToolGrid" method="_on_ToolsButton_pressed"]
+[connection signal="pressed" from="ToolGrid/Slot1" to="ToolGrid" method="_on_Slot_pressed" binds= [ 1 ]]

--- a/Scrum Age/Board.tscn
+++ b/Scrum Age/Board.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=20 format=2]
+[gd_scene load_steps=21 format=2]
 
 [ext_resource path="res://assets/gwent board.png" type="Texture" id=1]
 [ext_resource path="res://Board.gd" type="Script" id=2]
@@ -39,6 +39,10 @@ font_data = ExtResource( 4 )
 
 [sub_resource type="DynamicFont" id=7]
 size = 40
+font_data = ExtResource( 4 )
+
+[sub_resource type="DynamicFont" id=8]
+size = 60
 font_data = ExtResource( 4 )
 
 [node name="Board" type="Node2D"]
@@ -526,6 +530,28 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
+[node name="EndTurn" type="Button" parent="."]
+margin_left = 524.0
+margin_top = 670.0
+margin_right = 818.0
+margin_bottom = 767.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Label" type="Label" parent="EndTurn"]
+margin_left = 31.9897
+margin_top = 10.7194
+margin_right = 259.99
+margin_bottom = 78.7194
+custom_fonts/font = SubResource( 8 )
+text = "END TURN"
+align = 1
+valign = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
 [connection signal="pressed" from="RequirementsGrid/Slot1" to="RequirementsGrid" method="_on_Slot_pressed" binds= [ 1 ]]
 [connection signal="pressed" from="RequirementsGrid/Slot2" to="RequirementsGrid" method="_on_Slot_pressed" binds= [ 2 ]]
 [connection signal="pressed" from="RequirementsGrid/Slot3" to="RequirementsGrid" method="_on_Slot_pressed" binds= [ 3 ]]
@@ -574,3 +600,4 @@ __meta__ = {
 [connection signal="pressed" from="HRGrid/Slot1" to="HRGrid" method="_on_Slot_pressed" binds= [ 1 ]]
 [connection signal="pressed" from="HRGrid/Slot2" to="HRGrid" method="_on_Slot_pressed" binds= [ 2 ]]
 [connection signal="pressed" from="ToolGrid/Slot1" to="ToolGrid" method="_on_Slot_pressed" binds= [ 1 ]]
+[connection signal="pressed" from="EndTurn" to="." method="end_Turn"]

--- a/Scrum Age/Global.gd
+++ b/Scrum Age/Global.gd
@@ -6,6 +6,7 @@ var player_names = ["", "", "", "", ""]
 var meeple_counts = [3, 3, 3, 3, 3]
 var meeple_min = 0;
 var meeple_max = [3, 3, 3, 3, 3]
+var num_players = 5
 
 func _ready():
 	var root = get_tree().get_root()

--- a/Scrum Age/HRGrid.gd
+++ b/Scrum Age/HRGrid.gd
@@ -1,9 +1,11 @@
 extends GridContainer
 
 #Variable to check WHO is in what slot on the map. 0-5, (0 EMPTY, 1 = P1, 2 = P2, etc)
-var booleanSlotArray = [0, 0, 0, 0, 0, 0, 0, 0, 0]
+var booleanSlotArray = [0, 0]
 
-
+func _on_Slot_pressed(slot):
+	
+	get_parent().touch_slot(get_name(), slot)
 
 ##Get colored textures associated with each player, based on player value calling method (NEEDS TO BE UPDATED)
 #func _get_Fill_Color(player):

--- a/Scrum Age/HRGrid.gd
+++ b/Scrum Age/HRGrid.gd
@@ -5,7 +5,7 @@ var booleanSlotArray = [0, 0]
 
 func _on_Slot_pressed(slot):
 	
-	get_parent().touch_slot(get_name(), slot)
+	get_parent().touchHR_slot(get_name(), slot)
 
 ##Get colored textures associated with each player, based on player value calling method (NEEDS TO BE UPDATED)
 #func _get_Fill_Color(player):

--- a/Scrum Age/MainMenu.gd
+++ b/Scrum Age/MainMenu.gd
@@ -13,6 +13,7 @@ func _ready():
 #	pass
 
 func _on_Start_pressed():
+	Global.num_players = get_node("VBoxContainer/NumPlayersContainer/VBoxContainer/NumPlayersSpinBox").value
 	Global.goto_scene("res://Board.tscn")
 	Music.play_board_music()
 
@@ -22,50 +23,50 @@ func _on_End_pressed():
 
 
 func _on_PlayerOne_text_changed(new_text):
-	Global.player_names[0] = $VBoxContainer/VBoxContainer/PlayerOne.text
+	Global.player_names[0] = $VBoxContainer/LineEditsContainer/PlayerOne.text
 
 
 func _on_PlayerTwo_text_changed(new_text):
-	Global.player_names[1]= 	$VBoxContainer/VBoxContainer/PlayerTwo.text
+	Global.player_names[1]= 	$VBoxContainer/LineEditsContainer/PlayerTwo.text
 
 
 func _on_PlayerThree_text_changed(new_text):
-	Global.player_names[2] = $VBoxContainer/VBoxContainer/PlayerThree.text
+	Global.player_names[2] = $VBoxContainer/LineEditsContainer/PlayerThree.text
 
 
 func _on_PlayerFour_text_changed(new_text):
-	Global.player_names[3] = $VBoxContainer/VBoxContainer/PlayerFour.text
+	Global.player_names[3] = $VBoxContainer/LineEditsContainer/PlayerFour.text
 	
 
 func _on_PlayerFive_text_changed(new_text):
-	Global.player_names[4] = $VBoxContainer/VBoxContainer/PlayerFive.text
+	Global.player_names[4] = $VBoxContainer/LineEditsContainer/PlayerFive.text
 
 func _on_SpinBox_value_changed(value):
 	if value == 2:
-		$VBoxContainer/VBoxContainer/PlayerThree.set_visible(false)
-		$VBoxContainer/VBoxContainer/PlayerThree.text = ""
+		$VBoxContainer/LineEditsContainer/PlayerThree.set_visible(false)
+		$VBoxContainer/LineEditsContainer/PlayerThree.text = ""
 		Global.player_names[2] = ""
-		$VBoxContainer/VBoxContainer/PlayerFour.set_visible(false)
-		$VBoxContainer/VBoxContainer/PlayerFour.text = ""
+		$VBoxContainer/LineEditsContainer/PlayerFour.set_visible(false)
+		$VBoxContainer/LineEditsContainer/PlayerFour.text = ""
 		Global.player_names[3] = ""
-		$VBoxContainer/VBoxContainer/PlayerFive.set_visible(false)
-		$VBoxContainer/VBoxContainer/PlayerFive.text = ""
+		$VBoxContainer/LineEditsContainer/PlayerFive.set_visible(false)
+		$VBoxContainer/LineEditsContainer/PlayerFive.text = ""
 		Global.player_names[4] = ""
 	elif value == 3:
-		$VBoxContainer/VBoxContainer/PlayerThree.set_visible(true)
-		$VBoxContainer/VBoxContainer/PlayerFour.set_visible(false)
-		$VBoxContainer/VBoxContainer/PlayerFour.text = ""
+		$VBoxContainer/LineEditsContainer/PlayerThree.set_visible(true)
+		$VBoxContainer/LineEditsContainer/PlayerFour.set_visible(false)
+		$VBoxContainer/LineEditsContainer/PlayerFour.text = ""
 		Global.player_names[3] = ""
-		$VBoxContainer/VBoxContainer/PlayerFive.set_visible(false)
-		$VBoxContainer/VBoxContainer/PlayerFive.text = ""
+		$VBoxContainer/LineEditsContainer/PlayerFive.set_visible(false)
+		$VBoxContainer/LineEditsContainer/PlayerFive.text = ""
 		Global.player_names[4] = ""
 	elif value == 4:
-		$VBoxContainer/VBoxContainer/PlayerThree.set_visible(true)
-		$VBoxContainer/VBoxContainer/PlayerFour.set_visible(true)
-		$VBoxContainer/VBoxContainer/PlayerFive.set_visible(false)
-		$VBoxContainer/VBoxContainer/PlayerFive.text = ""
+		$VBoxContainer/LineEditsContainer/PlayerThree.set_visible(true)
+		$VBoxContainer/LineEditsContainer/PlayerFour.set_visible(true)
+		$VBoxContainer/LineEditsContainer/PlayerFive.set_visible(false)
+		$VBoxContainer/LineEditsContainer/PlayerFive.text = ""
 		Global.player_names[4] = ""
 	elif value == 5:
-		$VBoxContainer/VBoxContainer/PlayerThree.set_visible(true)
-		$VBoxContainer/VBoxContainer/PlayerFour.set_visible(true)
-		$VBoxContainer/VBoxContainer/PlayerFive.set_visible(true)
+		$VBoxContainer/LineEditsContainer/PlayerThree.set_visible(true)
+		$VBoxContainer/LineEditsContainer/PlayerFour.set_visible(true)
+		$VBoxContainer/LineEditsContainer/PlayerFive.set_visible(true)

--- a/Scrum Age/MainMenu.tscn
+++ b/Scrum Age/MainMenu.tscn
@@ -71,18 +71,18 @@ text = "Scrum Age"
 align = 1
 valign = 1
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+[node name="NumPlayersContainer" type="HBoxContainer" parent="VBoxContainer"]
 margin_top = 173.0
 margin_right = 1135.0
 margin_bottom = 205.0
 alignment = 1
 
-[node name="VBoxContainer2" type="VBoxContainer" parent="VBoxContainer/HBoxContainer"]
+[node name="VBoxContainer2" type="VBoxContainer" parent="VBoxContainer/NumPlayersContainer"]
 margin_left = 429.0
 margin_right = 627.0
 margin_bottom = 32.0
 
-[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer/VBoxContainer2"]
+[node name="NumPlayersLabel" type="Label" parent="VBoxContainer/NumPlayersContainer/VBoxContainer2"]
 margin_right = 198.0
 margin_bottom = 32.0
 size_flags_horizontal = 0
@@ -95,13 +95,13 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/NumPlayersContainer"]
 margin_left = 631.0
 margin_right = 705.0
 margin_bottom = 32.0
 alignment = 1
 
-[node name="SpinBox" type="SpinBox" parent="VBoxContainer/HBoxContainer/VBoxContainer"]
+[node name="NumPlayersSpinBox" type="SpinBox" parent="VBoxContainer/NumPlayersContainer/VBoxContainer"]
 margin_top = 4.0
 margin_right = 74.0
 margin_bottom = 28.0
@@ -112,7 +112,7 @@ max_value = 5.0
 value = 2.0
 align = 1
 
-[node name="ListOfPlayers" type="Label" parent="VBoxContainer"]
+[node name="ListOfPlayersLabel" type="Label" parent="VBoxContainer"]
 margin_top = 209.0
 margin_right = 1135.0
 margin_bottom = 264.0
@@ -121,14 +121,14 @@ custom_colors/font_outline_modulate = Color( 0, 0, 0, 1 )
 text = "List of Players"
 align = 1
 
-[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer"]
+[node name="LineEditsContainer" type="VBoxContainer" parent="VBoxContainer"]
 margin_top = 268.0
 margin_right = 1135.0
 margin_bottom = 437.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="PlayerOne" type="LineEdit" parent="VBoxContainer/VBoxContainer"]
+[node name="PlayerOne" type="LineEdit" parent="VBoxContainer/LineEditsContainer"]
 margin_left = 442.0
 margin_right = 692.0
 margin_bottom = 82.0
@@ -140,7 +140,7 @@ align = 1
 max_length = 12
 placeholder_text = "Player One"
 
-[node name="PlayerTwo" type="LineEdit" parent="VBoxContainer/VBoxContainer"]
+[node name="PlayerTwo" type="LineEdit" parent="VBoxContainer/LineEditsContainer"]
 margin_left = 442.0
 margin_top = 86.0
 margin_right = 692.0
@@ -153,7 +153,7 @@ align = 1
 max_length = 12
 placeholder_text = "Player Two"
 
-[node name="PlayerThree" type="LineEdit" parent="VBoxContainer/VBoxContainer"]
+[node name="PlayerThree" type="LineEdit" parent="VBoxContainer/LineEditsContainer"]
 visible = false
 margin_left = 438.0
 margin_top = 111.0
@@ -167,7 +167,7 @@ align = 1
 max_length = 12
 placeholder_text = "Player Three"
 
-[node name="PlayerFour" type="LineEdit" parent="VBoxContainer/VBoxContainer"]
+[node name="PlayerFour" type="LineEdit" parent="VBoxContainer/LineEditsContainer"]
 visible = false
 margin_left = 438.0
 margin_top = 125.0
@@ -181,7 +181,7 @@ align = 1
 max_length = 12
 placeholder_text = "Player Four"
 
-[node name="PlayerFive" type="LineEdit" parent="VBoxContainer/VBoxContainer"]
+[node name="PlayerFive" type="LineEdit" parent="VBoxContainer/LineEditsContainer"]
 visible = false
 margin_left = 438.0
 margin_top = 133.0
@@ -231,15 +231,15 @@ margin_bottom = 620.0
 size_flags_vertical = 1
 custom_fonts/font = SubResource( 7 )
 custom_colors/font_outline_modulate = Color( 0, 0, 0, 1 )
-text = "Version 0.2 The critically acclaimed MMORPG Final Fantasy XIV with a
+text = "Version 0.3 The critically acclaimed MMORPG Final Fantasy XIV with a
 free trial until level 60 including the Heavensward Expansion"
 align = 1
 
-[connection signal="value_changed" from="VBoxContainer/HBoxContainer/VBoxContainer/SpinBox" to="." method="_on_SpinBox_value_changed"]
-[connection signal="text_changed" from="VBoxContainer/VBoxContainer/PlayerOne" to="." method="_on_PlayerOne_text_changed"]
-[connection signal="text_changed" from="VBoxContainer/VBoxContainer/PlayerTwo" to="." method="_on_PlayerTwo_text_changed"]
-[connection signal="text_changed" from="VBoxContainer/VBoxContainer/PlayerThree" to="." method="_on_PlayerThree_text_changed"]
-[connection signal="text_changed" from="VBoxContainer/VBoxContainer/PlayerFour" to="." method="_on_PlayerFour_text_changed"]
-[connection signal="text_changed" from="VBoxContainer/VBoxContainer/PlayerFive" to="." method="_on_PlayerFive_text_changed"]
+[connection signal="value_changed" from="VBoxContainer/NumPlayersContainer/VBoxContainer/NumPlayersSpinBox" to="." method="_on_SpinBox_value_changed"]
+[connection signal="text_changed" from="VBoxContainer/LineEditsContainer/PlayerOne" to="." method="_on_PlayerOne_text_changed"]
+[connection signal="text_changed" from="VBoxContainer/LineEditsContainer/PlayerTwo" to="." method="_on_PlayerTwo_text_changed"]
+[connection signal="text_changed" from="VBoxContainer/LineEditsContainer/PlayerThree" to="." method="_on_PlayerThree_text_changed"]
+[connection signal="text_changed" from="VBoxContainer/LineEditsContainer/PlayerFour" to="." method="_on_PlayerFour_text_changed"]
+[connection signal="text_changed" from="VBoxContainer/LineEditsContainer/PlayerFive" to="." method="_on_PlayerFive_text_changed"]
 [connection signal="pressed" from="VBoxContainer/MenuOptions/Start" to="." method="_on_Start_pressed"]
 [connection signal="pressed" from="VBoxContainer/MenuOptions/End" to="." method="_on_End_pressed"]

--- a/Scrum Age/PlayerMenu.gd
+++ b/Scrum Age/PlayerMenu.gd
@@ -19,14 +19,11 @@ func _ready():
 		else:
 			turnOrder[first + i] = nameArray[i]
 	
-	#debugging
-	print(numPlayers)
-
-	get_node("Players/HBoxContainer1/MarginContainer/Player1/NameLabel").text = turnOrder[0]
-	get_node("Players/HBoxContainer2/MarginContainer/Player2/NameLabel").text = turnOrder[1]
-	get_node("Players/HBoxContainer3/MarginContainer/Player3/NameLabel").text = turnOrder[2]
-	get_node("Players/HBoxContainer4/MarginContainer/Player4/NameLabel").text = turnOrder[3]
-	get_node("Players/HBoxContainer5/MarginContainer/Player5/NameLabel").text = turnOrder[4]
+	for i in range(0,5):
+		if i < numPlayers:
+			get_node("Players/HBoxContainer"+str(i+1)+"/MarginContainer/Player"+str(i+1)+"/NameLabel").text = turnOrder[i]
+		else:
+			get_node("Players/HBoxContainer"+str(i+1)+"/MarginContainer/Player"+str(i+1)).visible = false
 
 func updateMeepleLabels(player):
 	get_node("Players/HBoxContainer"+str(player)+"/MarginContainer/Player"+str(player)+"/MeeplesLabel").text = str(Global.meeple_counts[player-1]) + "/" + str(Global.meeple_max[player-1]);

--- a/Scrum Age/PlayerMenu.gd
+++ b/Scrum Age/PlayerMenu.gd
@@ -7,6 +7,7 @@ var numPlayers = 5
 func _ready():
 	var random = RandomNumberGenerator.new()
 	random.randomize()
+	get_node("Players/HBoxContainer1/MarginContainer/Player1/TurnIndicatorP1").visible = true
 	
 	for i in range(0,5):
 		if (nameArray[i] == ""):
@@ -29,5 +30,8 @@ func _ready():
 
 func updateMeepleLabels(player):
 	get_node("Players/HBoxContainer"+str(player)+"/MarginContainer/Player"+str(player)+"/MeeplesLabel").text = str(Global.meeple_counts[0]) + "/" + str(Global.meeple_max[0]);
-#func showTurn(player):
-#	get_node("Players/HBoxContainer"+str(player)+"/MarginContainer/Player"+str(player)+"/TurnIndicator").visible = false;
+
+func showTurn(player):
+		get_node("Players/HBoxContainer"+str(player)+"/MarginContainer/Player"+str(player)+"/TurnIndicatorP"+str(player)).visible = true
+		get_node("Players/HBoxContainer"+str(player-1)+"/MarginContainer/Player"+str(player-1)+"/TurnIndicatorP"+str(player-1)).visible = false
+	

--- a/Scrum Age/PlayerMenu.gd
+++ b/Scrum Age/PlayerMenu.gd
@@ -29,3 +29,5 @@ func _ready():
 
 func updateMeepleLabels(player):
 	get_node("Players/HBoxContainer"+str(player)+"/MarginContainer/Player"+str(player)+"/MeeplesLabel").text = str(Global.meeple_counts[0]) + "/" + str(Global.meeple_max[0]);
+func showTurn(player):
+	get_node("Players/HBoxContainer"+str(player)+"/MarginContainer/Player"+str(player)+"/TurnIndicator").visible = false;

--- a/Scrum Age/PlayerMenu.gd
+++ b/Scrum Age/PlayerMenu.gd
@@ -29,7 +29,7 @@ func _ready():
 	get_node("Players/HBoxContainer5/MarginContainer/Player5/NameLabel").text = turnOrder[4]
 
 func updateMeepleLabels(player):
-	get_node("Players/HBoxContainer"+str(player)+"/MarginContainer/Player"+str(player)+"/MeeplesLabel").text = str(Global.meeple_counts[0]) + "/" + str(Global.meeple_max[0]);
+	get_node("Players/HBoxContainer"+str(player)+"/MarginContainer/Player"+str(player)+"/MeeplesLabel").text = str(Global.meeple_counts[player-1]) + "/" + str(Global.meeple_max[player-1]);
 
 func showTurn(player):
 		get_node("Players/HBoxContainer"+str(player)+"/MarginContainer/Player"+str(player)+"/TurnIndicatorP"+str(player)).visible = true

--- a/Scrum Age/PlayerMenu.gd
+++ b/Scrum Age/PlayerMenu.gd
@@ -9,10 +9,7 @@ func _ready():
 	random.randomize()
 	get_node("Players/HBoxContainer1/MarginContainer/Player1/TurnIndicatorP1").visible = true
 	
-	for i in range(0,5):
-		if (nameArray[i] == ""):
-			numPlayers = i
-			break
+	numPlayers = Global.num_players
 	
 	var first = random.randi_range(0, numPlayers - 1)
 	
@@ -21,6 +18,9 @@ func _ready():
 			turnOrder[first + i - numPlayers] = nameArray[i]
 		else:
 			turnOrder[first + i] = nameArray[i]
+	
+	#debugging
+	print(numPlayers)
 
 	get_node("Players/HBoxContainer1/MarginContainer/Player1/NameLabel").text = turnOrder[0]
 	get_node("Players/HBoxContainer2/MarginContainer/Player2/NameLabel").text = turnOrder[1]

--- a/Scrum Age/PlayerMenu.gd
+++ b/Scrum Age/PlayerMenu.gd
@@ -29,5 +29,5 @@ func _ready():
 
 func updateMeepleLabels(player):
 	get_node("Players/HBoxContainer"+str(player)+"/MarginContainer/Player"+str(player)+"/MeeplesLabel").text = str(Global.meeple_counts[0]) + "/" + str(Global.meeple_max[0]);
-func showTurn(player):
-	get_node("Players/HBoxContainer"+str(player)+"/MarginContainer/Player"+str(player)+"/TurnIndicator").visible = false;
+#func showTurn(player):
+#	get_node("Players/HBoxContainer"+str(player)+"/MarginContainer/Player"+str(player)+"/TurnIndicator").visible = false;

--- a/Scrum Age/PlayerMenu.tscn
+++ b/Scrum Age/PlayerMenu.tscn
@@ -43,6 +43,7 @@ rect_min_size = Vector2( 275, 0 )
 texture = ExtResource( 4 )
 
 [node name="TurnIndicatorP1" type="TextureRect" parent="Players/HBoxContainer1/MarginContainer/Player1"]
+visible = false
 anchor_top = -0.021189
 anchor_bottom = -0.021189
 margin_left = 4.0
@@ -131,6 +132,7 @@ rect_min_size = Vector2( 275, 0 )
 texture = ExtResource( 4 )
 
 [node name="TurnIndicatorP2" type="TextureRect" parent="Players/HBoxContainer2/MarginContainer/Player2"]
+visible = false
 margin_left = 4.0
 margin_top = 9.0
 margin_right = 35.0
@@ -215,6 +217,7 @@ rect_min_size = Vector2( 275, 0 )
 texture = ExtResource( 4 )
 
 [node name="TurnIndicatorP3" type="TextureRect" parent="Players/HBoxContainer3/MarginContainer/Player3"]
+visible = false
 margin_left = 4.0
 margin_top = 9.0
 margin_right = 35.0
@@ -296,6 +299,7 @@ rect_min_size = Vector2( 275, 0 )
 texture = ExtResource( 4 )
 
 [node name="TurnIndicatorP4" type="TextureRect" parent="Players/HBoxContainer4/MarginContainer/Player4"]
+visible = false
 margin_left = 4.0
 margin_top = 9.0
 margin_right = 35.0
@@ -381,6 +385,7 @@ rect_pivot_offset = Vector2( -214.692, -234 )
 texture = ExtResource( 4 )
 
 [node name="TurnIndicatorP5" type="TextureRect" parent="Players/HBoxContainer5/MarginContainer/Player5"]
+visible = false
 margin_left = 4.0
 margin_top = 9.0
 margin_right = 35.0

--- a/Scrum Age/PlayerMenu.tscn
+++ b/Scrum Age/PlayerMenu.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://PlayerMenu.gd" type="Script" id=1]
 [ext_resource path="res://assets/flag2.png" type="Texture" id=2]
-[ext_resource path="res://assets/empty.png" type="Texture" id=3]
 [ext_resource path="res://assets/label_HP_bg.png" type="Texture" id=4]
 [ext_resource path="res://assets/Meeples/Knight-1/1_head_.png" type="Texture" id=5]
 
@@ -136,7 +135,7 @@ margin_left = 4.0
 margin_top = 9.0
 margin_right = 35.0
 margin_bottom = 40.0
-texture = ExtResource( 3 )
+texture = ExtResource( 2 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -220,7 +219,7 @@ margin_left = 4.0
 margin_top = 9.0
 margin_right = 35.0
 margin_bottom = 40.0
-texture = ExtResource( 3 )
+texture = ExtResource( 2 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -301,7 +300,7 @@ margin_left = 4.0
 margin_top = 9.0
 margin_right = 35.0
 margin_bottom = 40.0
-texture = ExtResource( 3 )
+texture = ExtResource( 2 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -386,7 +385,10 @@ margin_left = 4.0
 margin_top = 9.0
 margin_right = 35.0
 margin_bottom = 40.0
-texture = ExtResource( 3 )
+texture = ExtResource( 2 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="NameLabel" type="Label" parent="Players/HBoxContainer5/MarginContainer/Player5"]
 anchor_top = 0.5

--- a/Scrum Age/ToolGrid.gd
+++ b/Scrum Age/ToolGrid.gd
@@ -1,7 +1,11 @@
 extends GridContainer
 
 #Variable to check WHO is in what slot on the map. 0-5, (0 EMPTY, 1 = P1, 2 = P2, etc)
-var booleanSlotArray = [0]
+var booleanSlotArray = [0, 0]
+
+func _on_Slot_pressed(slot):
+	
+	get_parent().touch_slot(get_name(), slot)
 
 ##Get colored textures associated with each player, based on player value calling method (NEEDS TO BE UPDATED)
 #func _get_Fill_Color(player):


### PR DESCRIPTION
As a player, I need to place meeples in different areas until I run out of meeples to place.
As a player, I want to be able to end my turn so that the next player can take their turn.
As a player, I want the turn indicator to increment with the players in the turn order so that I know whose turn it is.
As a player, I want to only see the names of players that were added to the game on the HUD so that I know how many players there are